### PR TITLE
Ships android menus

### DIFF
--- a/jsettlers.logic/src/main/java/jsettlers/logic/buildings/workers/WorkerBuilding.java
+++ b/jsettlers.logic/src/main/java/jsettlers/logic/buildings/workers/WorkerBuilding.java
@@ -216,6 +216,7 @@ public class WorkerBuilding extends WorkAreaBuilding implements IWorkerRequestBu
 			if (this.ship.getStateProgress() >= .99) {
 				this.ship = null;
 				this.order = null;
+				this.orderedShipType = null;
 			}
 		}
 	}
@@ -256,5 +257,9 @@ public class WorkerBuilding extends WorkAreaBuilding implements IWorkerRequestBu
 			}
 		}
 		return null;
+	}
+
+	public EMovableType getOrderedShipType() {
+		return orderedShipType;
 	}
 }

--- a/jsettlers.logic/src/main/java/jsettlers/logic/map/grid/partition/manager/manageables/interfaces/IWorkerRequestBuilding.java
+++ b/jsettlers.logic/src/main/java/jsettlers/logic/map/grid/partition/manager/manageables/interfaces/IWorkerRequestBuilding.java
@@ -83,4 +83,6 @@ public interface IWorkerRequestBuilding extends IPlayerable, ILocatable, IBuildi
 	void reduceOrder();
 
 	void buildShipAction();
+
+	EMovableType getOrderedShipType();
 }

--- a/jsettlers.main.android/src/main/java/jsettlers/main/android/gameplay/ui/fragments/MapFragment.java
+++ b/jsettlers.main.android/src/main/java/jsettlers/main/android/gameplay/ui/fragments/MapFragment.java
@@ -190,13 +190,13 @@ public class MapFragment extends Fragment implements SelectionListener, BackPres
 			return true;
 		}
 
-		if (selectionControls.getCurrentSelection() != null) {
-			selectionControls.deselect();
+		if (isMenuOpen()) {
+			dismissMenu();
 			return true;
 		}
 
-		if (isMenuOpen()) {
-			dismissMenu();
+		if (selectionControls.getCurrentSelection() != null) {
+			selectionControls.deselect();
 			return true;
 		}
 

--- a/jsettlers.main.android/src/main/java/jsettlers/main/android/gameplay/ui/fragments/MapFragment.java
+++ b/jsettlers.main.android/src/main/java/jsettlers/main/android/gameplay/ui/fragments/MapFragment.java
@@ -328,7 +328,6 @@ public class MapFragment extends Fragment implements SelectionListener, BackPres
 					.commit();
 			break;
 		case SPECIALISTS:
-			showMenu();
 			getChildFragmentManager().beginTransaction()
 					.replace(R.id.container_menu, SpecialistsSelectionFragment.newInstance(), TAG_FRAGMENT_SELECTION_MENU)
 					.commit();
@@ -340,7 +339,6 @@ public class MapFragment extends Fragment implements SelectionListener, BackPres
 					.commit();
 			break;
 		case SHIPS:
-			showMenu();
 			getChildFragmentManager().beginTransaction()
 					.replace(R.id.container_menu, ShipsSelectionFragment.newInstance(), TAG_FRAGMENT_SELECTION_MENU)
 					.commit();

--- a/jsettlers.main.android/src/main/java/jsettlers/main/android/gameplay/ui/fragments/menus/selection/features/DockFeature.java
+++ b/jsettlers.main.android/src/main/java/jsettlers/main/android/gameplay/ui/fragments/menus/selection/features/DockFeature.java
@@ -51,6 +51,7 @@ public class DockFeature extends SelectionFeature implements DrawListener, Actio
 	private final DrawControls drawControls;
 	private final ActionControls actionControls;
 	private final TaskControls taskControls;
+	private final MenuNavigator menuNavigator;
 
 	private final InGameButton placeDockButton;
 	private final ImageView ferryImageShip;
@@ -65,10 +66,11 @@ public class DockFeature extends SelectionFeature implements DrawListener, Actio
 		this.drawControls = drawControls;
 		this.actionControls = actionControls;
 		this.taskControls = taskControls;
+		this.menuNavigator = menuNavigator;
 
 		placeDockButton = (InGameButton) getView().findViewById(R.id.imageView_placeDock);
 		placeDockButton.setVisibility(View.VISIBLE);
-		placeDockButton.setOnClickListener(v -> actionControls.fireAction(new Action(EActionType.ASK_SET_DOCK)));
+		placeDockButton.setOnClickListener(this::setDockClicked);
 		OriginalImageProvider.get(placeDockImageLink).setAsImage(placeDockButton.getImageView());
 
 		ferryImageShip = (ImageView) getView().findViewById(R.id.imageView_ferry);
@@ -142,6 +144,11 @@ public class DockFeature extends SelectionFeature implements DrawListener, Actio
 
 			currentOrderedShip = orderedShip;
 		}
+	}
+
+	private void setDockClicked(View view) {
+		actionControls.fireAction(new Action(EActionType.ASK_SET_DOCK));
+		menuNavigator.dismissMenu();
 	}
 
 	private void dismissSnackbar() {

--- a/jsettlers.main.android/src/main/java/jsettlers/main/android/gameplay/ui/fragments/menus/selection/features/DockFeature.java
+++ b/jsettlers.main.android/src/main/java/jsettlers/main/android/gameplay/ui/fragments/menus/selection/features/DockFeature.java
@@ -24,8 +24,10 @@ import jsettlers.common.buildings.IBuilding;
 import jsettlers.common.images.ImageLink;
 import jsettlers.common.menu.action.EActionType;
 import jsettlers.common.menu.action.IAction;
+import jsettlers.common.movable.EMovableType;
 import jsettlers.graphics.action.Action;
 import jsettlers.graphics.map.controls.original.panel.selection.BuildingState;
+import jsettlers.logic.map.grid.partition.manager.manageables.interfaces.IWorkerRequestBuilding;
 import jsettlers.main.android.R;
 import jsettlers.main.android.core.controls.ActionControls;
 import jsettlers.main.android.core.controls.ActionListener;
@@ -36,12 +38,16 @@ import jsettlers.main.android.gameplay.navigation.MenuNavigator;
 import jsettlers.main.android.gameplay.ui.customviews.InGameButton;
 import jsettlers.main.android.utils.OriginalImageProvider;
 
-import static jsettlers.common.menu.action.EActionType.ABORT;
-
 /**
  * Created by Tom Pratt on 10/01/2017.
  */
 public class DockFeature extends SelectionFeature implements DrawListener, ActionListener {
+	private final ImageLink ferryImageLink = ImageLink.fromName("original_14_GUI_272", 0);
+	private final ImageLink ferrySelectedImageLink = ImageLink.fromName("original_14_GUI_273", 0);
+	private final ImageLink tradeShipImageLink = ImageLink.fromName("original_14_GUI_278", 0);
+	private final ImageLink tradeShipSelectedImageLink = ImageLink.fromName("original_14_GUI_279", 0);
+	private final ImageLink placeDockImageLink = ImageLink.fromName("original_3_GUI_390", 0);
+
 	private final DrawControls drawControls;
 	private final ActionControls actionControls;
 	private final TaskControls taskControls;
@@ -49,6 +55,8 @@ public class DockFeature extends SelectionFeature implements DrawListener, Actio
 	private final InGameButton placeDockButton;
 	private final ImageView ferryImageShip;
 	private final ImageView tradeShipImageView;
+
+	private EMovableType currentOrderedShip = null;
 
 	private Snackbar snackbar;
 
@@ -61,15 +69,15 @@ public class DockFeature extends SelectionFeature implements DrawListener, Actio
 		placeDockButton = (InGameButton) getView().findViewById(R.id.imageView_placeDock);
 		placeDockButton.setVisibility(View.VISIBLE);
 		placeDockButton.setOnClickListener(v -> actionControls.fireAction(new Action(EActionType.ASK_SET_DOCK)));
-		OriginalImageProvider.get(ImageLink.fromName("original_3_GUI_390", 0)).setAsImage(placeDockButton.getImageView());
+		OriginalImageProvider.get(placeDockImageLink).setAsImage(placeDockButton.getImageView());
 
 		ferryImageShip = (ImageView) getView().findViewById(R.id.imageView_ferry);
 		ferryImageShip.setOnClickListener(v -> actionControls.fireAction(new Action(EActionType.MAKE_FERRY)));
-		OriginalImageProvider.get(ImageLink.fromName("original_14_GUI_272", 0)).setAsImage(ferryImageShip);
+		OriginalImageProvider.get(ferryImageLink).setAsImage(ferryImageShip);
 
 		tradeShipImageView = (ImageView) getView().findViewById(R.id.imageView_tradeShip);
 		tradeShipImageView.setOnClickListener(v -> actionControls.fireAction(new Action(EActionType.MAKE_CARGO_BOAT)));
-		OriginalImageProvider.get(ImageLink.fromName("original_14_GUI_278", 0)).setAsImage(tradeShipImageView);
+		OriginalImageProvider.get(tradeShipImageLink).setAsImage(tradeShipImageView);
 	}
 
 	@Override
@@ -113,6 +121,27 @@ public class DockFeature extends SelectionFeature implements DrawListener, Actio
 	}
 
 	private void update() {
+		IWorkerRequestBuilding workerRequestBuilding = (IWorkerRequestBuilding) getBuilding();
+		EMovableType orderedShip = workerRequestBuilding.getOrderedShipType();
+
+		if (currentOrderedShip != orderedShip) {
+			switch (orderedShip) {
+				case FERRY:
+					OriginalImageProvider.get(ferrySelectedImageLink).setAsImage(ferryImageShip);
+					OriginalImageProvider.get(tradeShipImageLink).setAsImage(tradeShipImageView);
+					break;
+				case CARGO_BOAT:
+					OriginalImageProvider.get(ferryImageLink).setAsImage(ferryImageShip);
+					OriginalImageProvider.get(tradeShipSelectedImageLink).setAsImage(tradeShipImageView);
+					break;
+				default:
+					OriginalImageProvider.get(ferryImageLink).setAsImage(ferryImageShip);
+					OriginalImageProvider.get(tradeShipImageLink).setAsImage(tradeShipImageView);
+					break;
+			}
+
+			currentOrderedShip = orderedShip;
+		}
 	}
 
 	private void dismissSnackbar() {

--- a/jsettlers.main.android/src/main/java/jsettlers/main/android/gameplay/ui/fragments/menus/selection/features/WorkAreaFeature.java
+++ b/jsettlers.main.android/src/main/java/jsettlers/main/android/gameplay/ui/fragments/menus/selection/features/WorkAreaFeature.java
@@ -40,6 +40,7 @@ public class WorkAreaFeature extends SelectionFeature implements ActionListener 
 
 	private final ActionControls actionControls;
 	private final TaskControls taskControls;
+	private final MenuNavigator menuNavigator;
 
 	private Snackbar snackbar;
 
@@ -47,6 +48,7 @@ public class WorkAreaFeature extends SelectionFeature implements ActionListener 
 		super(view, building, menuNavigator);
 		this.actionControls = actionControls;
 		this.taskControls = taskControls;
+		this.menuNavigator = menuNavigator;
 	}
 
 	@Override
@@ -58,7 +60,7 @@ public class WorkAreaFeature extends SelectionFeature implements ActionListener 
 		ImageLink imageLink = ImageLink.fromName(image, 0);
 		OriginalImageProvider.get(imageLink).setAsImage(workAreaButton.getImageView());
 
-		workAreaButton.setOnClickListener(view -> actionControls.fireAction(new Action(EActionType.ASK_SET_WORK_AREA)));
+		workAreaButton.setOnClickListener(this::workAreaClicked);
 
 		actionControls.addActionListener(this);
 	}
@@ -83,6 +85,11 @@ public class WorkAreaFeature extends SelectionFeature implements ActionListener 
 		case ABORT:
 			dismissSnackbar();
 		}
+	}
+
+	private void workAreaClicked(View view) {
+		actionControls.fireAction(new Action(EActionType.ASK_SET_WORK_AREA));
+		menuNavigator.dismissMenu();
 	}
 
 	private void dismissSnackbar() {


### PR DESCRIPTION
made it so the construct ship buttons look pressed.

menu closes when you press the back button, pressing again deselects movables.

